### PR TITLE
Add some codeblocks to a docs page + change the edit on github url

### DIFF
--- a/docs-www/src/layouts/Main.astro
+++ b/docs-www/src/layouts/Main.astro
@@ -8,7 +8,7 @@ export let content;
 const headers = content?.astro?.headers;
 let editHref = Astro?.request?.url?.pathname?.slice(1) ?? '';
 if (editHref === '') editHref = `index`;
-editHref = `https://github.com/snowpackjs/astro/tree/main/examples/doc/src/pages/${editHref}.md`
+editHref = `https://github.com/snowpackjs/astro/tree/main/docs-www/src/pages/${editHref}.md`
 ---
 
 <html>

--- a/docs-www/src/pages/core-concepts/project-structure.md
+++ b/docs-www/src/pages/core-concepts/project-structure.md
@@ -6,26 +6,28 @@ layout: ~/layouts/Main.astro
 
 ## Basic Structure
 
+```
 ├── src/
 │   ├── components/
 │   └── pages/
 │       └── index.astro
 ├── public/
 └── package.json
+```
 
 ## Src Folder
 
-The src folder is where three types of subfolders live in.
+The `src` folder is where three types of subfolders live in.
 
 ## Components Folder
 
 Components are reusable parts of your pages.
 Components can currently be created with the following default extensions:
-- .astro an Astro component
-- .jsx a React / Preact component
-- .svelte a Svelte component
-- .tsx a TypeScript React / Preact component
-- .vue a Vue component
+- `.astro` an Astro component
+- `.jsx` a React / Preact component
+- `.svelte` a Svelte component
+- `.tsx` a TypeScript React / Preact component
+- `.vue` a Vue component
 
 The extension handling can be configured with the [extensions property](https://6c2de08d-66d6-482f-9f8d-a61627d40e28.vscode-webview-test.com/vscode-resource/file///Users/jan-martinfruehwacht/Dendron/personal/technology/tech.astro.documentation.config.md)
 
@@ -39,8 +41,8 @@ The layouts folder can be used for holding markdown layouts. These layouts can t
 
 ## Pages folder
 The pages is the folder with all the entry points to your web page or application. Possible files in this folder are:
-- .astro files
-- .md Markdown files
+- `.astro` files
+- `.md` Markdown files
   
 See also [Routing](https://6c2de08d-66d6-482f-9f8d-a61627d40e28.vscode-webview-test.com/vscode-resource/file///Users/jan-martinfruehwacht/Dendron/personal/technology/tech.astro.documentation.routing.md)
 


### PR DESCRIPTION
## Changes

- What does this change?
- Be short and concise. Bullet points can help!
- Before/after screenshots can be helpful as well

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
- Adds codeblocks around some bits that need it
- Updates the "edit on Github" URL to reflect that this is in `/docs-www` not `/examples/docs`
